### PR TITLE
Fix autorun to load util functions

### DIFF
--- a/autorun.sh
+++ b/autorun.sh
@@ -8,6 +8,7 @@
 # Directory Path 
 SCRIPT_DIR="$(dirname "$(realpath "$0")")"
 main_script="${SCRIPT_DIR}/main.sh"
+source "${SCRIPT_DIR}/util/util_loader.sh"
 
 # Check a permission (execute -> chmod +x)
 if [[ ! -x "${main_script}" ]]; then


### PR DESCRIPTION
## Summary
- load util_loader.sh before permission check to access shared helper functions

## Testing
- `bash -n autorun.sh`
- `shellcheck autorun.sh`

------
https://chatgpt.com/codex/tasks/task_e_684a1f41f584832bac5ead767f129a6f